### PR TITLE
Fix registry rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3", "3.11"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7", "3.11"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"

--- a/news/1.bugfix.md
+++ b/news/1.bugfix.md
@@ -1,0 +1,1 @@
+Fix registry rebuild

--- a/news/2.removal.md
+++ b/news/2.removal.md
@@ -1,0 +1,1 @@
+Drop support fo py3.6

--- a/news/3.bugfix.md
+++ b/news/3.bugfix.md
@@ -1,0 +1,1 @@
+Add missing type annotation

--- a/src/extendable/main.py
+++ b/src/extendable/main.py
@@ -179,7 +179,7 @@ class ExtendableMeta(ABCMeta):
     def _wrap_class_methods(metacls, namespace: Dict[str, Any]) -> Dict[str, Any]:
         """Wrap classmethods defined into the namespace to delegate the call to the
         final class."""
-        new_namespace = {}
+        new_namespace: Dict[str, Any] = {}
         for key, value in namespace.items():
             if isinstance(value, classmethod):
                 func = value.__func__

--- a/src/extendable/main.py
+++ b/src/extendable/main.py
@@ -59,6 +59,21 @@ class ExtendableClassDef:
             f"{self.namespace['__module__']}.{self.namespace['__qualname__']}"
         )
 
+    def clone(self) -> "ExtendableClassDef":
+        """Clone the class definition, but not the class itself nor the information
+        about the hierarchy.
+
+        This is used to allow to recompute the registry from scratch by
+        starting from the original class definition. This definition is
+        then modified by the build process to define the class
+        hierarchy.
+        """
+        clone = ExtendableClassDef(
+            self.original_name, self.others_bases, self.namespace, self.metaclass
+        )
+        clone.original_cls = self.original_cls
+        return clone
+
 
 _extendable_class_defs_by_module: OrderedDict[
     str, List[ExtendableClassDef]

--- a/src/extendable/registry.py
+++ b/src/extendable/registry.py
@@ -49,7 +49,7 @@ class ExtendableClassesRegistry:
         if module in self._loaded_modules:
             return
         for cls_def in main._extendable_class_defs_by_module.get(module, []):
-            self.load_extendable_class_def(cls_def)
+            self.load_extendable_class_def(cls_def.clone())
         self._loaded_modules.add(module)
 
     def load_extendable_class_def(self, cls_def: main.ExtendableClassDef) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37, typing
     3.8: py38, typing
     3.9: py39, typing, pypi-description
@@ -11,7 +10,6 @@ python =
 [tox]
 isolated_build = True
 envlist =
-    py36
     py37
     py38
     py39

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ python =
     3.9: py39, typing, pypi-description
     3.10: py310, typing
     3.11: py311, typing
-    pypy3: pypy3
+    pypy-3.7: pypy37
 
 [tox]
 isolated_build = True
@@ -15,7 +15,7 @@ envlist =
     py39
     py310
     py311
-    pypy3
+    pypy37
     lint
     typing
     pypi-description


### PR DESCRIPTION
Before this change, reloading the registry generated corrupted classes. This is because the original definition of class fragments to be assembled is modified during the build process. If this process was restarted, the definition would no longer be the original one, but the one containing the class hierarchy calculated during the previous build. When building the registry, this problem is avoided by taking a copy of the original definition as the starting point for assembling the class.